### PR TITLE
[SMS-52] Optimistic locking

### DIFF
--- a/src/main/java/vu/psk/ugems/controller/TaskController.java
+++ b/src/main/java/vu/psk/ugems/controller/TaskController.java
@@ -1,5 +1,8 @@
 package vu.psk.ugems.controller;
 
+
+
+import jakarta.persistence.OptimisticLockException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -32,7 +35,11 @@ public class TaskController {
 
     @PutMapping
     public ResponseEntity<TaskDTO> updateTask(@RequestBody TaskDTO taskDto) {
-        return new ResponseEntity<>(taskService.updateTask(taskDto), HttpStatus.OK);
+        try {
+            return new ResponseEntity<>(taskService.updateTask(taskDto), HttpStatus.OK);
+        } catch (OptimisticLockException e) {
+            return new ResponseEntity<>(HttpStatus.CONFLICT);
+        }
     }
 
     @DeleteMapping("/{taskId}")

--- a/src/main/java/vu/psk/ugems/controller/TaskController.java
+++ b/src/main/java/vu/psk/ugems/controller/TaskController.java
@@ -1,11 +1,10 @@
 package vu.psk.ugems.controller;
 
 
-
-import jakarta.persistence.OptimisticLockException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.web.bind.annotation.*;
 import vu.psk.ugems.dto.TaskDTO;
 import vu.psk.ugems.service.TaskService;
@@ -37,7 +36,7 @@ public class TaskController {
     public ResponseEntity<TaskDTO> updateTask(@RequestBody TaskDTO taskDto) {
         try {
             return new ResponseEntity<>(taskService.updateTask(taskDto), HttpStatus.OK);
-        } catch (OptimisticLockException e) {
+        } catch (ObjectOptimisticLockingFailureException e) {
             return new ResponseEntity<>(HttpStatus.CONFLICT);
         }
     }

--- a/src/main/java/vu/psk/ugems/dto/TaskDTO.java
+++ b/src/main/java/vu/psk/ugems/dto/TaskDTO.java
@@ -18,6 +18,7 @@ public class TaskDTO {
     private String description;
     private LocalDate deadline;
     private String status;
+    private Long version;
     private Long groupId;
     private Long assignedToId;
     private Long createdById;

--- a/src/main/java/vu/psk/ugems/entity/Task.java
+++ b/src/main/java/vu/psk/ugems/entity/Task.java
@@ -27,6 +27,9 @@ public class Task {
     private String description;
     private LocalDate deadline;
 
+    @Version
+    private Long version;
+
     @Enumerated(EnumType.STRING)
     private Status status;
 

--- a/src/main/java/vu/psk/ugems/service/TaskService.java
+++ b/src/main/java/vu/psk/ugems/service/TaskService.java
@@ -1,10 +1,10 @@
 package vu.psk.ugems.service;
 
 import jakarta.persistence.EntityNotFoundException;
+import jakarta.persistence.OptimisticLockException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import vu.psk.ugems.dto.TaskDTO;
-import vu.psk.ugems.entity.Task;
 import vu.psk.ugems.enums.Status;
 import vu.psk.ugems.mapper.TaskMapper;
 import vu.psk.ugems.repository.GroupRepository;
@@ -13,6 +13,7 @@ import vu.psk.ugems.repository.TaskRepository;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Objects;
 
 @Service
 @RequiredArgsConstructor
@@ -73,6 +74,10 @@ public class TaskService {
 
         var taskToUpdate = taskRepository.findById(taskDto.getId())
                 .orElseThrow(() -> new EntityNotFoundException("Task with ID " + taskDto.getId() + " not found"));
+
+        if (!Objects.equals(taskToUpdate.getVersion(), taskDto.getVersion())) {
+            throw new OptimisticLockException("Task has been updated already.");
+        }
 
         if (taskDto.getTitle() != null) {
             taskToUpdate.setTitle(taskDto.getTitle());

--- a/src/main/java/vu/psk/ugems/service/TaskService.java
+++ b/src/main/java/vu/psk/ugems/service/TaskService.java
@@ -1,13 +1,12 @@
 package vu.psk.ugems.service;
 
-import jakarta.persistence.EntityNotFoundException;
-import jakarta.persistence.OptimisticLockException;
+
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import vu.psk.ugems.dto.TaskDTO;
+import vu.psk.ugems.entity.Task;
 import vu.psk.ugems.enums.Status;
 import vu.psk.ugems.interceptor.LoggedAction;
-import vu.psk.ugems.exception.AccessDeniedException;
 import vu.psk.ugems.exception.ResourceNotFoundException;
 import vu.psk.ugems.mapper.TaskMapper;
 import vu.psk.ugems.repository.GroupRepository;
@@ -82,12 +81,25 @@ public class TaskService {
 
     public TaskDTO updateTask(TaskDTO taskDto) {
 
-        var taskToUpdate = taskRepository.findById(taskDto.getId())
+        var task = taskRepository.findById(taskDto.getId())
                 .orElseThrow(() -> new ResourceNotFoundException("Task with ID " + taskDto.getId() + " not found"));
 
-        if (!Objects.equals(taskToUpdate.getVersion(), taskDto.getVersion())) {
-            throw new OptimisticLockException("Task has been updated already.");
-        }
+        Task taskToUpdate = new Task();
+        taskToUpdate.setId(task.getId());
+        taskToUpdate.setTitle(task.getTitle());
+        taskToUpdate.setCreatedDate(task.getCreatedDate());
+        taskToUpdate.setAssignedDate(task.getAssignedDate());
+        taskToUpdate.setDescription(task.getDescription());
+        taskToUpdate.setDeadline(task.getDeadline());
+        taskToUpdate.setStatus(task.getStatus());
+        taskToUpdate.setGroup(task.getGroup());
+        taskToUpdate.setCreatedBy(task.getCreatedBy());
+        taskToUpdate.setAssignedTo(task.getAssignedTo());
+        taskToUpdate.setVersion(taskDto.getVersion());
+
+//        if (!Objects.equals(taskToUpdate.getVersion(), taskDto.getVersion())) {
+//            throw new OptimisticLockException("Task has been updated already.");
+//        }
 
         if (taskDto.getTitle() != null) {
             taskToUpdate.setTitle(taskDto.getTitle());
@@ -97,6 +109,9 @@ public class TaskService {
         }
         if (taskDto.getDeadline() != null) {
             taskToUpdate.setDeadline(taskDto.getDeadline());
+        }
+        else {
+            taskToUpdate.setDeadline(null);
         }
         if (taskDto.getStatus() != null) {
             taskToUpdate.setStatus(Status.valueOf(taskDto.getStatus()));
@@ -113,7 +128,8 @@ public class TaskService {
             taskToUpdate.setAssignedDate(null);
         }
 
-        return taskMapper.toDto(taskRepository.save(taskToUpdate));
+        var updatedTask = taskRepository.save(taskToUpdate);
+        return taskMapper.toDto(updatedTask);
     }
 
     public void deleteTask(Long id) {


### PR DESCRIPTION
Optimistic locking for task updates. Implemented by using @Version to track task version, but exception is thrown manually if the task received via request isn't the same version as the same one in database. Task and TaskDTO now have version field.